### PR TITLE
enabled daubering

### DIFF
--- a/src/DauberLayer.js
+++ b/src/DauberLayer.js
@@ -4,10 +4,11 @@ import WordTile from './WordTile.js';
 
 export default function DauberLayer(props) {
   return (
-    <div className={props.styleclass}><WordTile word={props.word} /></div>
+    <WordTile word={props.word} styleClass={props.styleClass} handleTileClick={props.handleTileClick}/>
   );
 }
 DauberLayer.propTypes = {
   word: PropTypes.string,
-  styleclass: PropTypes.string
+  styleClass: PropTypes.string,
+  handleTileClick: PropTypes.func
 };

--- a/src/DauberLayer.js
+++ b/src/DauberLayer.js
@@ -4,11 +4,16 @@ import WordTile from './WordTile.js';
 
 export default function DauberLayer(props) {
   return (
-    <WordTile word={props.word} styleClass={props.styleClass} handleTileClick={props.handleTileClick}/>
+    <div className={props.styleClass} onClick={props.handleTileClick} id={props.id}>
+      <WordTile
+        word={props.word}
+      />
+    </div>
   );
 }
 DauberLayer.propTypes = {
   word: PropTypes.string,
   styleClass: PropTypes.string,
-  handleTileClick: PropTypes.func
+  handleTileClick: PropTypes.func,
+  id: PropTypes.number
 };

--- a/src/Gameboard.js
+++ b/src/Gameboard.js
@@ -9,6 +9,12 @@ import wordProcessor from './funcLib/WordProcessor.js';
 import './tempstyle.css';
 
 export default class Gameboard extends React.Component {
+  constructor(props){
+    super(props);
+    this.state = {
+      dauberedTiles : [],
+    };
+  }
   rowBuilder(randWords) {
     let result = [];
     for (let row = 0; row < 5; row++) {
@@ -25,15 +31,22 @@ export default class Gameboard extends React.Component {
       const currentWord = randWords[idx];
       result.push(
         <Col key={idx} className='word-tile'>
-          <DauberLayer styleClass='plain' word={currentWord}
+          <DauberLayer id={idx} styleClass={this.state.dauberedTiles[idx] ? 'daubered' : 'plain'} word={currentWord}
             handleTileClick={e => this.handleTileClick(e)}/>
         </Col>);
     }
     return result;
   }
   handleTileClick(e){
-    e.target.className='daubered';
-    console.log('click');
+    let id = e.currentTarget.id;
+    if(id !== null){
+      this.setState((prevState) => {
+        prevState.dauberedTiles[id] = true;
+        return {dauberedTiles: prevState.dauberedTiles};
+      });
+      console.log('click ' + id);
+      console.log(this.state.dauberedTiles);
+    }
   }
   render() {
     const randInts = randomGen(24);

--- a/src/Gameboard.js
+++ b/src/Gameboard.js
@@ -30,7 +30,9 @@ export default class Gameboard extends React.Component {
       const idx = col + incrementor;
       const currentWord = randWords[idx];
       result.push(
-        <Col key={idx} className='word-col'
+        <Col key={idx}
+          className='word-col'
+          // inline style is neccessary here to override the defualt style for 'Col'
           style={{ padding: 0 }}
         >
           <DauberLayer id={idx} styleClass={this.state.dauberedTiles[idx] ? 'daubered' : 'plain'} word={currentWord}

--- a/src/Gameboard.js
+++ b/src/Gameboard.js
@@ -18,25 +18,27 @@ export default class Gameboard extends React.Component {
   }
 
   tileBuilder(row, randWords) {
-    console.log('Gameboard itemBuilder(row) accessing param randWords: ' + randWords);
     let result = [];
     const incrementor = row * 5;
     for (let col=0; col < 5; col++) {
-      console.log('Gameboard itemBuilder(row) col: ' + col);
       const idx = col + incrementor;
-      console.log('Gameboard itemBuilder(row) idx: ' + idx);
       const currentWord = randWords[idx];
-      console.log('Gameboard itemBuilder(row) currentWord: ' + currentWord);
-      result.push(<Col key={idx} className='word-tile'><DauberLayer styleClass='daubered' word={currentWord}/></Col>);
+      result.push(
+        <Col key={idx} className='word-tile'>
+          <DauberLayer styleClass='plain' word={currentWord}
+            handleTileClick={e => this.handleTileClick(e)}/>
+        </Col>);
     }
     return result;
   }
-
+  handleTileClick(e){
+    e.target.className='daubered';
+    console.log('click');
+  }
   render() {
     const randInts = randomGen(24);
     let words = wordImporter();
     const randWords = wordProcessor(words, randInts);
-    console.log('Gameboard randWords: ' + randWords);
     const rows = this.rowBuilder(randWords);
 
     return (

--- a/src/Gameboard.js
+++ b/src/Gameboard.js
@@ -30,7 +30,9 @@ export default class Gameboard extends React.Component {
       const idx = col + incrementor;
       const currentWord = randWords[idx];
       result.push(
-        <Col key={idx} className='word-tile'>
+        <Col key={idx} className='word-col'
+          style={{ padding: 0 }}
+        >
           <DauberLayer id={idx} styleClass={this.state.dauberedTiles[idx] ? 'daubered' : 'plain'} word={currentWord}
             handleTileClick={e => this.handleTileClick(e)}/>
         </Col>);

--- a/src/WordTile.js
+++ b/src/WordTile.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 
 export default function WordTile(props) {
   return (
-    <div onClick={props.handleTileClick} className={props.styleClass}>{props.word}</div>
+    <div>
+      {props.word}
+    </div>
   );
 }
 WordTile.propTypes = {
   word: PropTypes.string,
-  styleClass: PropTypes.string,
-  handleTileClick: PropTypes.func
 };

--- a/src/WordTile.js
+++ b/src/WordTile.js
@@ -3,9 +3,11 @@ import PropTypes from 'prop-types';
 
 export default function WordTile(props) {
   return (
-    <div>{props.word}</div>
+    <div onClick={props.handleTileClick} className={props.styleClass}>{props.word}</div>
   );
 }
 WordTile.propTypes = {
-  word: PropTypes.string
+  word: PropTypes.string,
+  styleClass: PropTypes.string,
+  handleTileClick: PropTypes.func
 };

--- a/src/tempstyle.css
+++ b/src/tempstyle.css
@@ -40,6 +40,7 @@ section {
   border-radius: 4%;
 }
 
+
 .daubered {
   color: #010B24;
   border-radius: 50%;
@@ -53,6 +54,11 @@ section {
 
 .plain {
   background: #FFF2E8;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .dev-bio-image {

--- a/src/tempstyle.css
+++ b/src/tempstyle.css
@@ -29,7 +29,7 @@ section {
   width: 70%;
 }
 
-.word-tile {
+.word-col {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -39,7 +39,6 @@ section {
   border: solid 2px #9F4A04;
   border-radius: 4%;
 }
-
 
 .daubered {
   color: #010B24;
@@ -53,7 +52,7 @@ section {
 }
 
 .plain {
-  background: #FFF2E8;
+  background: #ffffff;
   width: 100%;
   height: 100%;
   display: flex;


### PR DESCRIPTION
Daubering is now applied when a word is clicked. Note that there are several imperfections with this implementation:

1. Daubering only works if the word itself is clicked, just clicking on a square won't do anything. This could be solved by expanding WordTile and/or DauberLayer to fill the containing Col component
2. The daubering class had to be applied directly to the top level div of the WordTile component to take effect. The current solution passes the styleClass prop directly through the DauberLayer component - which means that component currently fulfills no function. We should decide whether to keep the DauberLayer and modify the stylesheet so that child components/divs inherit the plain/daubered class, or to remove it. 