### PR TITLE
Add play again button

### DIFF
--- a/src/GameSession.js
+++ b/src/GameSession.js
@@ -4,15 +4,24 @@ import randomGen from './funcLib/RandomGen.js';
 import wordProcessor from './funcLib/WordProcessor.js';
 import wordImporter from './funcLib/WordImporter.js';
 import PlayAgainButton from './PlayAgainButton.js';
+import { Col, Container, Row } from 'react-bootstrap';
 
 export default function GameSession() {
   const randInts = randomGen(24);
   let words = wordImporter();
   const randWords = wordProcessor(words, randInts);
   return (
-    <div>
-      <Gameboard randwords={randWords} />
-      <PlayAgainButton className='center-button' disabled={false}/>
-    </div>
+    <Container fluid>
+      <Row>
+        <Col>
+          <Gameboard randwords={randWords} />
+        </Col>
+      </Row>
+      <Row>
+        <Col className='d-flex justify-content-center'> {/* Center the button */}
+          <PlayAgainButton disabled={false}/>
+        </Col>
+      </Row>
+    </Container>
   );
 }

--- a/src/GameSession.js
+++ b/src/GameSession.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Gameboard from './Gameboard.js';
 import randomGen from './funcLib/RandomGen.js';
 import wordProcessor from './funcLib/WordProcessor.js';
@@ -10,6 +10,7 @@ export default function GameSession() {
   const randInts = randomGen(24);
   let words = wordImporter();
   const randWords = wordProcessor(words, randInts);
+  const [restarts, setRestarts] = useState(0);
   return (
     <Container fluid>
       <Row>
@@ -19,7 +20,7 @@ export default function GameSession() {
       </Row>
       <Row>
         <Col className='d-flex justify-content-center'> {/* Center the button */}
-          <PlayAgainButton disabled={false}/>
+          <PlayAgainButton disabled={false} handleClick={ () => setRestarts(restarts + 1)}/>
         </Col>
       </Row>
     </Container>

--- a/src/GameSession.js
+++ b/src/GameSession.js
@@ -1,16 +1,16 @@
-import React, { useState } from 'react';
+import React from 'react';
 import Gameboard from './Gameboard.js';
 import randomGen from './funcLib/RandomGen.js';
 import wordProcessor from './funcLib/WordProcessor.js';
 import wordImporter from './funcLib/WordImporter.js';
 import PlayAgainButton from './PlayAgainButton.js';
 import { Col, Container, Row } from 'react-bootstrap';
+import { Link } from 'react-router-dom';
 
 export default function GameSession() {
   const randInts = randomGen(24);
   let words = wordImporter();
   const randWords = wordProcessor(words, randInts);
-  const [restarts, setRestarts] = useState(0);
   return (
     <Container fluid>
       <Row>
@@ -20,7 +20,8 @@ export default function GameSession() {
       </Row>
       <Row>
         <Col className='d-flex justify-content-center'> {/* Center the button */}
-          <PlayAgainButton disabled={false} handleClick={ () => setRestarts(restarts + 1)}/>
+          {/*reloadDocument parameter skips client-side routing so that page is refreshed and state is reset */}
+          <Link reloadDocument to={'../play'}><PlayAgainButton /></Link>
         </Col>
       </Row>
     </Container>

--- a/src/GameSession.js
+++ b/src/GameSession.js
@@ -3,13 +3,16 @@ import Gameboard from './Gameboard.js';
 import randomGen from './funcLib/RandomGen.js';
 import wordProcessor from './funcLib/WordProcessor.js';
 import wordImporter from './funcLib/WordImporter.js';
+import PlayAgainButton from './PlayAgainButton.js';
 
 export default function GameSession() {
   const randInts = randomGen(24);
   let words = wordImporter();
   const randWords = wordProcessor(words, randInts);
-
   return (
-    <Gameboard randwords={randWords} />
+    <div>
+      <Gameboard randwords={randWords} />
+      <PlayAgainButton className='center-button' disabled={false}/>
+    </div>
   );
 }

--- a/src/Gameboard.js
+++ b/src/Gameboard.js
@@ -46,8 +46,6 @@ export default class Gameboard extends React.Component {
         prevState.dauberedTiles[id] = true;
         return {dauberedTiles: prevState.dauberedTiles};
       });
-      console.log('click ' + id);
-      console.log(this.state.dauberedTiles);
     }
   }
   render() {

--- a/src/PlayAgainButton.js
+++ b/src/PlayAgainButton.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Button from 'react-bootstrap/Button';
+
+
+export default function PlayAgainButton(props){
+  return <Button disabled={props.disabled} className='center-button'>Play Again</Button>;
+}
+
+PlayAgainButton.propTypes = {
+  disabled: PropTypes.bool
+};

--- a/src/PlayAgainButton.js
+++ b/src/PlayAgainButton.js
@@ -4,10 +4,9 @@ import Button from 'react-bootstrap/Button';
 
 
 export default function PlayAgainButton(props){
-  return <Button onClick={props.handleClick} disabled={props.disabled}>Play Again</Button>;
+  return <Button onClick={props.handleClick}>Play Again</Button>;
 }
 
 PlayAgainButton.propTypes = {
-  disabled: PropTypes.bool,
   handleClick: PropTypes.func
 };

--- a/src/PlayAgainButton.js
+++ b/src/PlayAgainButton.js
@@ -1,12 +1,10 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import Button from 'react-bootstrap/Button';
 
 
-export default function PlayAgainButton(props){
-  return <Button onClick={props.handleClick}>Play Again</Button>;
+export default function PlayAgainButton(){
+  return <Button>Play Again</Button>;
 }
 
 PlayAgainButton.propTypes = {
-  handleClick: PropTypes.func
 };

--- a/src/PlayAgainButton.js
+++ b/src/PlayAgainButton.js
@@ -4,9 +4,10 @@ import Button from 'react-bootstrap/Button';
 
 
 export default function PlayAgainButton(props){
-  return <Button disabled={props.disabled} className='center-button'>Play Again</Button>;
+  return <Button onClick={props.handleClick} disabled={props.disabled}>Play Again</Button>;
 }
 
 PlayAgainButton.propTypes = {
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  handleClick: PropTypes.func
 };

--- a/src/tempstyle.css
+++ b/src/tempstyle.css
@@ -70,3 +70,7 @@ section {
   align-items: center;
   justify-content: center;
 }
+.center-button {
+  margin: 0, auto;
+  width: 100px;
+}


### PR DESCRIPTION
I added the play again button to the `GameSession` component. We discussed disabling the button until a user bingos, but I am leaving it enabled all the time for right now. Clicking the button increments a state variable called `restarts`, causing the GameSession component to rerender, and the game tiles to randomize again. For now, the button is just centered directly under the game board with default bootstrap button styling.