### PR TITLE
Toggle play again button

### DIFF
--- a/src/GameSession.js
+++ b/src/GameSession.js
@@ -12,9 +12,10 @@ export default function GameSession() {
   const [moves, setMoves] = useState(0);
   const [isBingoed, setBingoed] = useState(false);
   const [dauberedTiles, setDauberedTiles] = useState([]);
+  const [gamesStarted, setGamesStarted] = useState([1]);
   const randInts = randomGen(24);
   let words = wordImporter();
-  const randWords = wordProcessor(words, randInts);
+  const [randWords, setRandWords] = useState(wordProcessor(words, randInts));
 
   function handleTileClick(e) {
     let id = e.currentTarget.id;
@@ -27,15 +28,27 @@ export default function GameSession() {
     }
   }
 
+  function restartGame() {
+    setGamesStarted(gamesStarted + 1);
+    setMoves(0);
+    setDauberedTiles([]);
+    setGamesStarted(gamesStarted + 1);
+  }
+
   useEffect(() =>{
     setBingoed( checkForBingo(dauberedTiles, moves));
   },[moves]);
+
+  useEffect(() =>{
+    setRandWords(wordProcessor(words, randInts));
+  }, [gamesStarted]);
 
   return (
     <Container fluid>
       <Row>
         <Col>
-          <Gameboard randwords={randWords}
+          <Gameboard
+            randwords={randWords}
             moves={moves}
             isBingoed={isBingoed}
             dauberedTiles={dauberedTiles}
@@ -45,7 +58,9 @@ export default function GameSession() {
       <Row>
         <Col className='d-flex justify-content-center'> {/* Center the button */}
           {/*reloadDocument parameter skips client-side routing so that page is refreshed and state is reset */}
-          <Link reloadDocument to={'../play'}><PlayAgainButton /></Link>
+          <Link reloadDocument to={'../play'}>
+            <PlayAgainButton handleClick={() => restartGame()}/>
+          </Link>
         </Col>
       </Row>
     </Container>

--- a/src/GameSession.js
+++ b/src/GameSession.js
@@ -5,7 +5,6 @@ import wordProcessor from './funcLib/WordProcessor.js';
 import wordImporter from './funcLib/WordImporter.js';
 import PlayAgainButton from './PlayAgainButton.js';
 import { Col, Container, Row } from 'react-bootstrap';
-import { Link } from 'react-router-dom';
 import checkForBingo from './funcLib/CheckForBingo';
 
 export default function GameSession() {
@@ -57,10 +56,7 @@ export default function GameSession() {
       </Row>
       <Row>
         <Col className='d-flex justify-content-center'> {/* Center the button */}
-          {/*reloadDocument parameter skips client-side routing so that page is refreshed and state is reset */}
-          <Link reloadDocument to={'../play'}>
-            <PlayAgainButton handleClick={() => restartGame()}/>
-          </Link>
+          <PlayAgainButton handleClick={() => restartGame()}/>
         </Col>
       </Row>
     </Container>

--- a/src/GameSession.js
+++ b/src/GameSession.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import Gameboard from './Gameboard.js';
 import randomGen from './funcLib/RandomGen.js';
 import wordProcessor from './funcLib/WordProcessor.js';
@@ -6,16 +6,40 @@ import wordImporter from './funcLib/WordImporter.js';
 import PlayAgainButton from './PlayAgainButton.js';
 import { Col, Container, Row } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
+import checkForBingo from './funcLib/CheckForBingo';
 
 export default function GameSession() {
+  const [moves, setMoves] = useState(0);
+  const [isBingoed, setBingoed] = useState(false);
+  const [dauberedTiles, setDauberedTiles] = useState([]);
   const randInts = randomGen(24);
   let words = wordImporter();
   const randWords = wordProcessor(words, randInts);
+
+  function handleTileClick(e) {
+    let id = e.currentTarget.id;
+    if(id !== null) {
+      setDauberedTiles((prev) =>{
+        let modDauberedTiles = prev;
+        modDauberedTiles[id] = true;
+        return modDauberedTiles;});
+      setMoves(moves + 1);
+    }
+  }
+
+  useEffect(() =>{
+    setBingoed( checkForBingo(dauberedTiles, moves));
+  },[moves]);
+
   return (
     <Container fluid>
       <Row>
         <Col>
-          <Gameboard randwords={randWords} />
+          <Gameboard randwords={randWords}
+            moves={moves}
+            isBingoed={isBingoed}
+            dauberedTiles={dauberedTiles}
+            handleTileClick={(e) => handleTileClick(e)}/>
         </Col>
       </Row>
       <Row>

--- a/src/GameSession.js
+++ b/src/GameSession.js
@@ -56,7 +56,7 @@ export default function GameSession() {
       </Row>
       <Row>
         <Col className='d-flex justify-content-center'> {/* Center the button */}
-          <PlayAgainButton handleClick={() => restartGame()}/>
+          <PlayAgainButton isBingoed={isBingoed} handleClick={() => restartGame()}/>
         </Col>
       </Row>
     </Container>

--- a/src/GameSession.js
+++ b/src/GameSession.js
@@ -27,11 +27,22 @@ export default function GameSession() {
     }
   }
 
+  function dauberTile(id){
+    setDauberedTiles((prev) =>{
+      let modDauberedTiles = prev;
+      modDauberedTiles[id] = true;
+      return modDauberedTiles;});
+  }
+
   function restartGame() {
     setGamesStarted(gamesStarted + 1);
     setMoves(0);
     setDauberedTiles([]);
     setGamesStarted(gamesStarted + 1);
+  }
+
+  function dauberFreeSpace(){
+    dauberTile(12);
   }
 
   useEffect(() =>{
@@ -40,6 +51,7 @@ export default function GameSession() {
 
   useEffect(() =>{
     setRandWords(wordProcessor(words, randInts));
+    dauberFreeSpace();
   }, [gamesStarted]);
 
   return (

--- a/src/Gameboard.js
+++ b/src/Gameboard.js
@@ -5,22 +5,11 @@ import Col from 'react-bootstrap/Col';
 import Row from 'react-bootstrap/Row';
 import DauberLayer from './DauberLayer';
 import './tempstyle.css';
-import checkForBingo from './funcLib/CheckForBingo';
+
 
 export default class Gameboard extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      moves: 0,
-      isBingoed: false,
-      dauberedTiles: [
-        false, false, false, false, false,
-        false, false, false, false, false,
-        false, false, true, false, false,
-        false, false, false, false, false,
-        false, false, false, false, false,
-      ],
-    };
   }
 
   rowBuilder(randWords) {
@@ -43,26 +32,12 @@ export default class Gameboard extends React.Component {
           // inline style is neccessary here to override the defualt style for 'Col'
           style={{ padding: 0 }}
         >
-          <DauberLayer id={idx} styleClass={this.state.dauberedTiles[idx] ? 'daubered' : 'plain'} word={currentWord}
-            handleTileClick={e => this.handleTileClick(e)} />
+          <DauberLayer id={idx} styleClass={this.props.dauberedTiles[idx] ? 'daubered' : 'plain'} word={currentWord}
+            handleTileClick={e => this.props.handleTileClick(e)} />
         </Col>);
     }
     return result;
   }
-
-  handleTileClick(e) {
-    const incrMoves = this.state.moves + 1;
-    let id = e.currentTarget.id;
-
-    if (id !== null) {
-      this.setState((prevState) => {
-        prevState.dauberedTiles[id] = true;
-        prevState.moves = incrMoves;
-        return { dauberedTiles: prevState.dauberedTiles };
-      });
-    }
-  }
-
   renderGameboard(rows) {
     return (
       <Container fluid className='px-0' >
@@ -79,16 +54,18 @@ export default class Gameboard extends React.Component {
   render() {
     const rows = this.rowBuilder(this.props.randwords);
     const gameBoard = this.renderGameboard(rows);
-    const bingoed = checkForBingo(this.state.dauberedTiles, this.state.moves);
-
     return (
       <>
-        {bingoed === true ? <div>BINGO! In {this.state.moves} tiles!</div> : gameBoard}
+        {this.props.isBingoed === true ? <div>BINGO! In {this.props.moves} tiles!</div> : gameBoard}
       </>
     );
   }
 }
 
 Gameboard.propTypes = {
-  randwords: PropTypes.array
+  randwords: PropTypes.array,
+  moves: PropTypes.number,
+  dauberedTiles: PropTypes.array,
+  handleTileClick: PropTypes.func,
+  isBingoed: PropTypes.bool
 };

--- a/src/PlayAgainButton.js
+++ b/src/PlayAgainButton.js
@@ -5,11 +5,11 @@ import Button from 'react-bootstrap/Button';
 
 export default function PlayAgainButton(props){
   return <Button onClick={props.handleClick}>
-    {props.didBingo ? 'Play Again' : 'Restart Game'}
+    {props.isBingoed ? 'Play Again' : 'Restart Game'}
   </Button>;
 }
 
 PlayAgainButton.propTypes = {
-  didBingo: PropTypes.bool,
+  isBingoed: PropTypes.bool,
   handleClick: PropTypes.func
 };

--- a/src/PlayAgainButton.js
+++ b/src/PlayAgainButton.js
@@ -1,10 +1,15 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Button from 'react-bootstrap/Button';
 
 
-export default function PlayAgainButton(){
-  return <Button>Play Again</Button>;
+export default function PlayAgainButton(props){
+  return <Button onClick={props.handleClick}>
+    {props.didBingo ? 'Play Again' : 'Restart Game'}
+  </Button>;
 }
 
 PlayAgainButton.propTypes = {
+  didBingo: PropTypes.bool,
+  handleClick: PropTypes.func
 };


### PR DESCRIPTION
The Play Again button now says "Restart Game" until the user Bingos, when the text is changed to "Play Again".

To make the button responsive to user bingos, I lifted state into the GameSession component. In doing this, I was also able  to implement a gameReset function and pass it to PlayAgainButton as a prop. This also means that the browser doesn't have to make a full document request each time the PlayAgain button is clicked.

Note that randomWords is now a state variable. It is assigned on the initial render, and updated by the UseEffect hook each time the state variable gamesStarted is incremented. This was necessary to prevent the wordlist from being randomized on each rerender. 

I'm open to feedback on this, but I believe (besides solving the immediate issue of the PlayAgainButton needing to access state) that these changes will also have some slight performance benefits.

We can also disable the button, rather than change the text, if that's what we want to do.