### PR TITLE
Rules of hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@babel/preset-env": "^7.19.3",
         "@babel/preset-react": "^7.18.6",
         "babel-jest": "^29.1.2",
+        "eslint-plugin-react-hooks": "^4.6.0",
         "jest": "^27.5.1",
         "react-test-renderer": "^18.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,15 @@
     "extends": [
       "lingobingojs",
       "lingobingojs/jest"
-    ]
+    ],
+    "plugins": [
+      "react-hooks"
+    ],
+    "rules": {
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn"
+    }
+
   },
   "browserslist": {
     "production": [
@@ -43,9 +51,10 @@
     ]
   },
   "devDependencies": {
-    "@babel/preset-env":"^7.19.3",
-    "@babel/preset-react":"^7.18.6",
-    "babel-jest":"^29.1.2",
+    "@babel/preset-env": "^7.19.3",
+    "@babel/preset-react": "^7.18.6",
+    "babel-jest": "^29.1.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "jest": "^27.5.1",
     "react-test-renderer": "^18.2.0"
   }

--- a/src/GameSession.js
+++ b/src/GameSession.js
@@ -7,6 +7,7 @@ import PlayAgainButton from './PlayAgainButton.js';
 import { Col, Container, Row } from 'react-bootstrap';
 import checkForBingo from './funcLib/CheckForBingo';
 
+
 export default function GameSession() {
   const [moves, setMoves] = useState(0);
   const [isBingoed, setBingoed] = useState(false);
@@ -41,17 +42,13 @@ export default function GameSession() {
     setGamesStarted(gamesStarted + 1);
   }
 
-  function dauberFreeSpace(){
-    dauberTile(12);
-  }
-
   useEffect(() =>{
     setBingoed( checkForBingo(dauberedTiles, moves));
-  },[moves]);
+  },[dauberedTiles, moves]);
 
   useEffect(() =>{
     setRandWords(wordProcessor(words, randInts));
-    dauberFreeSpace();
+    dauberTile(12);
   }, [gamesStarted]);
 
   return (

--- a/src/GameSession.js
+++ b/src/GameSession.js
@@ -13,9 +13,13 @@ export default function GameSession() {
   const [isBingoed, setBingoed] = useState(false);
   const [dauberedTiles, setDauberedTiles] = useState([]);
   const [gamesStarted, setGamesStarted] = useState([1]);
-  const randInts = randomGen(24);
-  let words = wordImporter();
-  const [randWords, setRandWords] = useState(wordProcessor(words, randInts));
+  const [randWords, setRandWords] = useState(initRandomWords);
+
+  function initRandomWords(){
+    const randInts = randomGen(24);
+    let words = wordImporter();
+    return wordProcessor(words, randInts);
+  }
 
   function handleTileClick(e) {
     let id = e.currentTarget.id;
@@ -47,7 +51,8 @@ export default function GameSession() {
   },[dauberedTiles, moves]);
 
   useEffect(() =>{
-    setRandWords(wordProcessor(words, randInts));
+    setRandWords(initRandomWords());
+    // daubers center tile
     dauberTile(12);
   }, [gamesStarted]);
 

--- a/src/GameSession.js
+++ b/src/GameSession.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, { useEffect, useState } from 'react';
 import Gameboard from './Gameboard.js';
 import randomGen from './funcLib/RandomGen.js';
 import wordProcessor from './funcLib/WordProcessor.js';
@@ -7,15 +7,14 @@ import PlayAgainButton from './PlayAgainButton.js';
 import { Col, Container, Row } from 'react-bootstrap';
 import checkForBingo from './funcLib/CheckForBingo';
 
-
 export default function GameSession() {
   const [moves, setMoves] = useState(0);
   const [isBingoed, setBingoed] = useState(false);
   const [dauberedTiles, setDauberedTiles] = useState([]);
   const [gamesStarted, setGamesStarted] = useState([1]);
-  const [randWords, setRandWords] = useState(initRandomWords);
+  const [randWords, setRandWords] = useState(initRandomWords());
 
-  function initRandomWords(){
+  function initRandomWords() {
     const randInts = randomGen(24);
     let words = wordImporter();
     return wordProcessor(words, randInts);
@@ -23,20 +22,22 @@ export default function GameSession() {
 
   function handleTileClick(e) {
     let id = e.currentTarget.id;
-    if(id !== null) {
-      setDauberedTiles((prev) =>{
+    if (id !== null) {
+      setDauberedTiles((prev) => {
         let modDauberedTiles = prev;
         modDauberedTiles[id] = true;
-        return modDauberedTiles;});
+        return modDauberedTiles;
+      });
       setMoves(moves + 1);
     }
   }
 
-  function dauberTile(id){
-    setDauberedTiles((prev) =>{
+  function dauberTile(id) {
+    setDauberedTiles((prev) => {
       let modDauberedTiles = prev;
       modDauberedTiles[id] = true;
-      return modDauberedTiles;});
+      return modDauberedTiles;
+    });
   }
 
   function restartGame() {
@@ -46,11 +47,11 @@ export default function GameSession() {
     setGamesStarted(gamesStarted + 1);
   }
 
-  useEffect(() =>{
-    setBingoed( checkForBingo(dauberedTiles, moves));
-  },[dauberedTiles, moves]);
+  useEffect(() => {
+    setBingoed(checkForBingo(dauberedTiles, moves));
+  }, [dauberedTiles, moves]);
 
-  useEffect(() =>{
+  useEffect(() => {
     setRandWords(initRandomWords());
     // daubers center tile
     dauberTile(12);
@@ -65,12 +66,18 @@ export default function GameSession() {
             moves={moves}
             isBingoed={isBingoed}
             dauberedTiles={dauberedTiles}
-            handleTileClick={(e) => handleTileClick(e)}/>
+            handleTileClick={(e) => handleTileClick(e)}
+          />
         </Col>
       </Row>
       <Row>
-        <Col className='d-flex justify-content-center'> {/* Center the button */}
-          <PlayAgainButton isBingoed={isBingoed} handleClick={() => restartGame()}/>
+        <Col className="d-flex justify-content-center">
+          {' '}
+          {/* Center the button */}
+          <PlayAgainButton
+            isBingoed={isBingoed}
+            handleClick={() => restartGame()}
+          />
         </Col>
       </Row>
     </Container>

--- a/src/screenpartystyle.css
+++ b/src/screenpartystyle.css
@@ -7,6 +7,7 @@ html, body {
   opacity: 0;
   width: 30px;
   height: 30px;
+  box-shadow: 0px 10px 1px  #796758;
 }
 
 .leftside {


### PR DESCRIPTION
The rules-of-hooks ESLint plugin had some complaints about missing dependencies in the dependency arrays for the useEffect calls in gameSession.js. This posed a dilemma, as we didn't want to call useEffect() every time some of these variables changed. This was resolved by eliminating variables at the top-level scope of the component and moving functions only intended to run on useEffect() call into the useEffect hook. This required three changes to GameSession:

1. Moved all code for generating random word list into a function initRandomWords() that is only called during initial render and and on resets. This avoids assigning variables in the component that are reassigned at every render, eliminating the need to include them as a dependency in the useEffect hook. 
2. Included all variables referenced in useEffect calls in dependency arrays
3. Moved the code for daubering the center tile inside useEffect instead of calling it as an external function