### PR TITLE
Hover events

### DIFF
--- a/src/DauberLayer.js
+++ b/src/DauberLayer.js
@@ -5,7 +5,7 @@ import WordTile from './WordTile.js';
 export default function DauberLayer(props) {
   return (
     <div
-      className={props.styleClass + " enable-pointer highlight-tile"}
+      className={props.styleClass + ' enable-pointer highlight-tile'}
       data-theme={props.datatheme}
       onClick={props.handleTileClick}
       id={props.id}

--- a/src/DauberLayer.js
+++ b/src/DauberLayer.js
@@ -5,7 +5,7 @@ import WordTile from './WordTile.js';
 export default function DauberLayer(props) {
   return (
     <div
-      className={props.styleClass}
+      className={props.styleClass + " enable-pointer"}
       data-theme={props.datatheme}
       onClick={props.handleTileClick}
       id={props.id}

--- a/src/DauberLayer.js
+++ b/src/DauberLayer.js
@@ -5,7 +5,7 @@ import WordTile from './WordTile.js';
 export default function DauberLayer(props) {
   return (
     <div
-      className={props.styleClass + " enable-pointer"}
+      className={props.styleClass + " enable-pointer highlight-tile"}
       data-theme={props.datatheme}
       onClick={props.handleTileClick}
       id={props.id}

--- a/src/DevBio.js
+++ b/src/DevBio.js
@@ -25,13 +25,13 @@ export default function DevBio(props) {
           {props.bio}
         </Card.Text>
         <Card.Link
-          className='m-1'
+          className='m-1 enable-pointer'
           href={props.linkedin}
         >
           LinkedIn
         </Card.Link>
         <Card.Link
-          className='m-1'
+          className='m-1 enable-pointer'
           href={props.github}
         >
           GitHub

--- a/src/PlayAgainButton.js
+++ b/src/PlayAgainButton.js
@@ -4,7 +4,8 @@ import React from 'react';
 export default function PlayAgainButton(props) {
   return (
     <div
-      className='p-1 m-2 rounded-4 lets-play themed-text enable-pointer'
+      className='p-1 m-2 rounded-4 lets-play themed-button 
+      enable-pointer highlight-button'
       data-theme='light'
       onClick={props.handleClick}>
       {props.isBingoed ? 'Play Again' : 'Restart Game'}

--- a/src/PlayAgainButton.js
+++ b/src/PlayAgainButton.js
@@ -4,7 +4,7 @@ import React from 'react';
 export default function PlayAgainButton(props) {
   return (
     <div
-      className='p-1 m-2 rounded-4 lets-play themed-text'
+      className='p-1 m-2 rounded-4 lets-play themed-text enable-pointer'
       data-theme='light'
       onClick={props.handleClick}>
       {props.isBingoed ? 'Play Again' : 'Restart Game'}

--- a/src/WordTile.js
+++ b/src/WordTile.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 export default function WordTile(props) {
   return (
-    <div>
+    <div className='enable-pointer'>
       {props.word}
     </div>
   );

--- a/src/dev-theme.css
+++ b/src/dev-theme.css
@@ -51,3 +51,51 @@
   color: var(--rgba-primary-2);
   background-color: var(--rgba-primary-3);
 }
+
+.themed-button[data-theme='light'] {
+  color: var(--rgba-secondary-2-3);
+  background-color: var(--rgba-secondary-1-2);
+  border: solid 2px var(--rgba-secondary-2-3);
+}
+.themed-button[data-theme='dark'] {
+  color: var(--rgba-primary-2);
+  background-color: var(--rgba-primary-3);
+  border: solid 4px var(--rgba-secondary-2-4);
+}
+
+
+.highlight-button[data-theme=light]:hover {
+  background-color: var(--rgba-secondary-1-3);
+  color: var(--rgba-secondary-1-2);
+}
+.highlight-button[data-theme=dark]:hover {
+  background-color: var(--rgba-secondary-2-4);
+}
+.highlight-tile[data-theme=light]:hover {
+  background-color: var(--rgba-primary-1);
+  border-radius: 50%;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.highlight-tile[data-theme=dark]:hover {
+  background-color: var(--rgba-primary-1);;
+  border-radius: 50%;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.highlight-tile[data-theme=light]:active {
+  color: var(--rgba-primary-3); /* text */
+  background: var(--rgba-primary-2); /* dauber */
+}
+
+.highlight-tile[data-theme=dark]:active {
+  color: var(--rgba-primary-2); /* text */
+  background: var(--rgba-primary-3); /* dauber */
+}

--- a/src/tempstyle.css
+++ b/src/tempstyle.css
@@ -58,3 +58,7 @@ ul {
   list-style: none;
   margin-left: -2em;
 }
+
+.enable-pointer:hover {
+  cursor: pointer;
+}


### PR DESCRIPTION
Word tiles now have a "ghost-dauber" effect when hovering, and the reset button is highlighted on hover. The "finger pointer" now appears when hovering over word tiles, the rest button, and the links in the dev bio section.

I used CSS classes in dev-themes.css to do this. I afforded some consideration for which colors to use in the light theme version, but haven't tested the dark theme colors.

I also applied a border around the Reset button to help make it look a bit more button like and distinguish it from the "Let's Play Bingo" flavor text at the top of the page.