### PR TITLE
Jr/bug devlinks broken

### DIFF
--- a/src/About.js
+++ b/src/About.js
@@ -19,8 +19,8 @@ export default function About() {
           img={dev.img}
           name={dev.name}
           bio={dev.bio}
-          linkedin={personalbar.linkedin}
-          github={personalbar.github}
+          linkedin={dev.linkedin}
+          github={dev.github}
         />
       </Col>);
   });

--- a/src/DevBio.js
+++ b/src/DevBio.js
@@ -25,13 +25,15 @@ export default function DevBio(props) {
           {props.bio}
         </Card.Text>
         <Card.Link
-          className='m-1 enable-pointer'
+          className='m-1 enable-pointer themed-hyperlink'
+          data-theme={props.dataTheme}
           href={props.linkedin}
         >
           LinkedIn
         </Card.Link>
         <Card.Link
-          className='m-1 enable-pointer'
+          className='m-1 enable-pointer themed-hyperlink'
+          data-theme={props.dataTheme}
           href={props.github}
         >
           GitHub

--- a/src/DevBio.js
+++ b/src/DevBio.js
@@ -25,14 +25,14 @@ export default function DevBio(props) {
           {props.bio}
         </Card.Text>
         <Card.Link
-          className='m-1 enable-pointer themed-hyperlink'
+          className='mx-auto my-1 enable-pointer themed-hyperlink'
           data-theme={props.dataTheme}
           href={props.linkedin}
         >
           LinkedIn
         </Card.Link>
         <Card.Link
-          className='m-1 enable-pointer themed-hyperlink'
+          className='mx-auto my-1 enable-pointer themed-hyperlink'
           data-theme={props.dataTheme}
           href={props.github}
         >

--- a/src/dev-theme.css
+++ b/src/dev-theme.css
@@ -71,6 +71,12 @@
   background-color: var( --rgba-secondary-1-0);
 }
 
+.themed-hyperlink[data-theme='dark']:link {
+  color: var(--rgba-primary-1);
+}
+.themed-hyperlink[data-theme='dark']:visited {
+  color: var(--rgba-secondary-1-0);
+}
 
 .highlight-button[data-theme=light]:hover {
   background-color: var(--rgba-secondary-1-3);
@@ -101,12 +107,12 @@
 
 .highlight-tile[data-theme=light]:active {
   color: var(--rgba-primary-3);
-  background: var(--rgba-primary-2); 
+  background: var(--rgba-primary-2);
 }
 
 .highlight-tile[data-theme=dark]:active {
-  color: var(--rgba-primary-2); 
-  background: var(--rgba-primary-3); 
+  color: var(--rgba-primary-2);
+  background: var(--rgba-primary-3);
 }
 
 .lets-play[data-theme=dark]{


### PR DESCRIPTION
Fix links in devbio so they actually link-out to their url destinations.

- [X] Update prop attributes so they call data from 'dev' props.
- [X] Adde theme for link class (only dark so light is not overridden).
- [X] Fix margins on Card.Link so finger cursor only when hovering link text (instead of entire box element).

We will want to consolidate all of the pseudo-class selectors into dev-theme.css so they will be guaranteed ordered correctly [lvha](https://developer.mozilla.org/en-US/docs/Web/CSS/:visited): Link, Visited, Hover, Active.

New bug added to Trello covering this.