### PR TITLE
embedded youtube video in description page

### DIFF
--- a/src/CSS/dev-theme.css
+++ b/src/CSS/dev-theme.css
@@ -274,3 +274,12 @@ ul > li {
   align-items: center;
   justify-content: center;
 }
+
+/*----------Description----------*/
+.demo-video {
+  min-width: 330px;
+  min-height: 200px;
+  width: 100%;
+  object-fit: scale-down;
+}
+

--- a/src/Components/Description.js
+++ b/src/Components/Description.js
@@ -57,6 +57,20 @@ export default function Description() {
         </Col>
         <Col md='auto'></Col>
       </Row>
+      <Row>
+        <Col md='auto'></Col>
+        <Col className='md-8'>
+          <iframe width="560"
+            height="315"
+            src="https://www.youtube.com/embed/nGCEpUAnkSg?controls=0&autoplay=1&mute=1&modestbranding=1&loop=1"
+            title="YouTube video player"
+            frameBorder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
+            allowfullscreen>
+          </iframe>
+        </Col>
+        <Col md='auto'></Col>
+      </Row>
       <Row className='p-2 mb-3'>
         <Col md='auto'></Col>
         <Col className='md-8'>

--- a/src/Components/Description.js
+++ b/src/Components/Description.js
@@ -57,14 +57,15 @@ export default function Description() {
         </Col>
         <Col md='auto'></Col>
       </Row>
-      <Row>
+      <Row className='p-2 mb-3'>
         <Col md='auto'></Col>
-        <Col className='md-8'>
-          <iframe width="560"
-            height="315"
-            src="https://www.youtube.com/embed/nGCEpUAnkSg?controls=0&autoplay=1&mute=1&modestbranding=1&loop=1"
-            title="YouTube video player"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
+        <Col>
+          <iframe className='demo-video rounded-4'
+            width="500"
+            height="500"
+            src="https://www.youtube.com/embed/P1yVieUmLPo?controls=0&autoplay=1&mute=1&modestbranding=1&loop=1"
+            title="Video showing how to play LingoBingoJS"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; loop"
             allowfullscreen>
           </iframe>
         </Col>

--- a/src/Components/Description.js
+++ b/src/Components/Description.js
@@ -64,7 +64,6 @@ export default function Description() {
             height="315"
             src="https://www.youtube.com/embed/nGCEpUAnkSg?controls=0&autoplay=1&mute=1&modestbranding=1&loop=1"
             title="YouTube video player"
-            frameBorder="0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
             allowfullscreen>
           </iframe>


### PR DESCRIPTION
- [x] Embed youtube iframe in description page
- [x] Add `mute`, `loop`, `autoplay` and `modestbranding` parameters to src url
- [x] Edit the id part of src url (just after `embed`) to show the correct video
- [x] Add appropriate css to position and style the video as needed