### PR TITLE
Jr/componentize tilebuilder

### DIFF
--- a/src/Components/Gameboard.js
+++ b/src/Components/Gameboard.js
@@ -3,53 +3,16 @@ import PropTypes from 'prop-types';
 import Container from 'react-bootstrap/Container';
 import Col from 'react-bootstrap/Col';
 import Row from 'react-bootstrap/Row';
-import DauberLayer from './DauberLayer';
 import PartyFavor from '../funcLib/PartyFavor';
 import glitterData from '../JSON/glitter-types.json';
 import BingoAnnouncer from './BingoAnnouncer';
+import rowBuilder from './RowBuilder';
+
 import '../CSS/screenpartystyle.css';
 
 export default class Gameboard extends React.Component {
   constructor(props) {
     super(props);
-  }
-
-  rowBuilder(randWords) {
-    let result = [];
-    for (let row = 0; row < 5; row++) {
-      result.push(
-        <Row
-          key={row}
-          className='mx-0'
-        >{this.tileBuilder(row, randWords)}</Row>
-      );
-    }
-    return result;
-  }
-
-  tileBuilder(row, randWords) {
-    let result = [];
-    const incrementor = row * 5;
-    for (let col = 0; col < 5; col++) {
-      const idx = col + incrementor;
-      const currentWord = randWords[idx];
-      result.push(
-        <Col key={idx}
-          className='word-col p-1'
-          data-theme={this.props.dataTheme}
-        >
-          <DauberLayer
-            id={idx}
-            styleClass={this.props.dauberedTiles[idx] ?
-              'daubered' :
-              'plain'}
-            dataTheme={this.props.dataTheme}
-            word={currentWord}
-            handleTileClick={e => this.props.handleTileClick(e)}
-          />
-        </Col>);
-    }
-    return result;
   }
 
   renderGameboard(rows) {
@@ -90,8 +53,10 @@ export default class Gameboard extends React.Component {
   }
 
   render() {
-    const rows = this.rowBuilder(this.props.randwords);
-    const gameBoard = this.renderGameboard(rows);
+    const rows = this.props.dauberedTiles
+      ? rowBuilder(this.props.randwords, this.props.dataTheme, this.props.dauberedTiles, this.props.handleTileClick)
+      : null;
+    const gameBoard = this.props.dauberedTiles ? this.renderGameboard(rows) : null;
     const currentMove = this.props.moves;
     const bingoAnnouncementText = 'B I N G O in ' + currentMove + ' words !';
     const partyfavors = this.getPartyFavors(bingoAnnouncementText);

--- a/src/Components/RowBuilder.js
+++ b/src/Components/RowBuilder.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Col, Row } from 'react-bootstrap';
+import DauberLayer from './DauberLayer';
+
+export default function RowBuilder(
+  randWords,
+  dataTheme,
+  dauberedTiles,
+  handleTileClick
+) {
+  function tileBuilder(row) {
+    let result = [];
+    const incrementor = row * 5;
+    for (let col = 0; col < 5; col++) {
+      const idx = col + incrementor;
+      const currentWord = randWords[idx];
+      result.push(
+        <Col key={idx} className="word-col p-1" data-theme={dataTheme}>
+          <DauberLayer
+            id={idx}
+            styleClass={dauberedTiles[idx] ? 'daubered' : 'plain'}
+            dataTheme={dataTheme}
+            word={currentWord}
+            handleTileClick={(e) => handleTileClick(e)}
+          />
+        </Col>
+      );
+    }
+    return result;
+  }
+
+  let result = [];
+  for (let row = 0; row < 5; row++) {
+    result.push(
+      <Row key={row} className="mx-0">
+        {tileBuilder(row)}
+      </Row>
+    );
+  }
+
+  return result;
+}


### PR DESCRIPTION
- [X] Remove functions rowBuilder and tileBuilder from Gameboard component.
- [X] Add RowBuilder Component.
- [X] Implement tileBuilder func in RowBuilder to simplify params dependencies.
- [X] Add Conditional Operators to block rendering Gameboard when dauberedTiles props is undefined.
- [X] Unit tests pass.

Hopefully Gameboard.js is a little less cluttered now.
RowBuilder explicitly calls TileBuilder, so it became a child component.
GameSession implements useEffect hooks so turnary statements were added to Gameboard to avoid rendering what amounts to a null-values game board.
