### PR TITLE
Fix click count incremented when clicking already clicked tile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16063,9 +16063,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.74.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+      "version": "5.76.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.2.tgz",
+      "integrity": "sha512-Th05ggRm23rVzEOlX8y67NkYCHa9nTNcwHPBhdg+lKG+mtiW7XgggjAeeLnADAe7mLjJ6LUNfgHAuRRh+Z6J7w==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -28474,9 +28474,9 @@
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
     },
     "webpack": {
-      "version": "5.74.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+      "version": "5.76.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.2.tgz",
+      "integrity": "sha512-Th05ggRm23rVzEOlX8y67NkYCHa9nTNcwHPBhdg+lKG+mtiW7XgggjAeeLnADAe7mLjJ6LUNfgHAuRRh+Z6J7w==",
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",

--- a/src/Components/GameSession.js
+++ b/src/Components/GameSession.js
@@ -22,15 +22,13 @@ export default function GameSession() {
     let id = e.currentTarget.id;
     if (id !== null) {
       const currentDauberedTiles = dauberedTiles;
-      currentDauberedTiles[id] = true;
-      let moveCount = -1;
-      currentDauberedTiles.forEach((tile) => {
-        if (tile === true) {
-          moveCount++;
-        }
-      });
-      setDauberedTiles(currentDauberedTiles);
-      setMoves(moveCount);
+      if (currentDauberedTiles[id] !== true) {
+        currentDauberedTiles[id] = true;
+        let moveCount = moves;
+        moveCount++;
+        setDauberedTiles(currentDauberedTiles);
+        setMoves(moveCount);
+      }
     }
   }
 

--- a/src/Components/GameSession.js
+++ b/src/Components/GameSession.js
@@ -17,7 +17,7 @@ export default function GameSession() {
   let {gameboardId, param2} = useParams();
   const [theme] = useOutletContext();
 
-  console.log(gameboardId + ' ' + param2);
+  console.log(gameboardId, param2);
 
   function initRandomWords() {
     const randInts = randomGen(24);
@@ -28,12 +28,16 @@ export default function GameSession() {
   function handleTileClick(e) {
     let id = e.currentTarget.id;
     if (id !== null) {
-      setDauberedTiles((prev) => {
-        let modDauberedTiles = prev;
-        modDauberedTiles[id] = true;
-        return modDauberedTiles;
+      const currentDauberedTiles = dauberedTiles;
+      currentDauberedTiles[id] = true;
+      let moveCount = -1;
+      currentDauberedTiles.forEach((tile) => {
+        if (tile === true) {
+          moveCount++;
+        }
       });
-      setMoves(moves + 1);
+      setDauberedTiles(currentDauberedTiles);
+      setMoves(moveCount);
     }
   }
 


### PR DESCRIPTION
Fixes the following bug:

Expected: The number of words that have been clicked at least once are returned during the Bingo Party statement “Bingo in n words!”.

Actual: The number of mouse-clicks on words on screen are counted.

Reproduce:

1. Click Play Lingo Bingo
1. Click a word 5 times (example: The top-left-hand word tile).
1. Click click more words just once to get a Bingo (example: 3 more, skipping FREE).
1. BingoParty launches and says “Bingo in 8 Words!”
